### PR TITLE
Add an option to get all versions of rows in the /diff API

### DIFF
--- a/src/it/java/org/opendatakit/aggregate/odktables/DataManagerTestIT.java
+++ b/src/it/java/org/opendatakit/aggregate/odktables/DataManagerTestIT.java
@@ -393,7 +393,7 @@ public class DataManagerTestIT {
     row = round3changes.get(0);
     expected.put(row.getRowId(), row);
 
-    WebsafeRows websafeRows = dm.getRowsSince(beginETag, null, 2000);
+    WebsafeRows websafeRows = dm.getRowsSince(beginETag, null, 2000, false);
     List<Row> actual = websafeRows.rows;
     Util.assertCollectionSameElements(expected.values(), actual);
   }

--- a/src/main/java/org/opendatakit/aggregate/odktables/DataManager.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/DataManager.java
@@ -303,7 +303,7 @@ public class DataManager {
    * @throws PermissionDeniedException
    * @throws BadColumnNameException
    */
-  public WebsafeRows getRowsSince(String dataETag, QueryResumePoint startCursor, int fetchLimit)
+  public WebsafeRows getRowsSince(String dataETag, QueryResumePoint startCursor, int fetchLimit, boolean fullLog)
       throws ODKDatastoreException, ODKTaskLockException, InconsistentStateException,
       PermissionDeniedException, BadColumnNameException {
 
@@ -377,7 +377,7 @@ public class DataManager {
         rows.add(row);
       }
     }
-    return new WebsafeRows(computeDiff(rows), currentDataETag, result.websafeRefetchCursor,
+    return new WebsafeRows(fullLog ? rows : computeDiff(rows), currentDataETag, result.websafeRefetchCursor,
         result.websafeBackwardCursor, result.websafeResumeCursor, result.hasMore, result.hasPrior);
   }
   

--- a/src/main/java/org/opendatakit/aggregate/odktables/api/DiffService.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/api/DiffService.java
@@ -39,6 +39,7 @@ public interface DiffService {
   public static final String QUERY_SEQUENCE_VALUE = "sequence_value";
   public static final String CURSOR_PARAMETER = "cursor";
   public static final String FETCH_LIMIT = "fetchLimit";
+  public static final String GET_FULL_LOG = "getFullLog";
 
   /**
    *
@@ -54,7 +55,7 @@ public interface DiffService {
    */
   @GET
   @Produces({MediaType.APPLICATION_JSON, ApiConstants.MEDIA_TEXT_XML_UTF8, ApiConstants.MEDIA_APPLICATION_XML_UTF8})
-  public Response /*RowResourceList*/ getRowsSince(@QueryParam(QUERY_DATA_ETAG) String dataETag, @QueryParam(CURSOR_PARAMETER) String cursor, @QueryParam(FETCH_LIMIT) String fetchLimit)
+  public Response /*RowResourceList*/ getRowsSince(@QueryParam(QUERY_DATA_ETAG) String dataETag, @QueryParam(CURSOR_PARAMETER) String cursor, @QueryParam(FETCH_LIMIT) String fetchLimit, @QueryParam(GET_FULL_LOG) String getFullLog)
       throws ODKDatastoreException, PermissionDeniedException, InconsistentStateException, ODKTaskLockException, BadColumnNameException;
   
   /**

--- a/src/main/java/org/opendatakit/aggregate/odktables/impl/api/DiffServiceImpl.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/impl/api/DiffServiceImpl.java
@@ -62,10 +62,11 @@ public class DiffServiceImpl implements DiffService {
   }
 
   @Override
-  public Response getRowsSince(@QueryParam(QUERY_DATA_ETAG) String dataETag, @QueryParam(CURSOR_PARAMETER) String cursor, @QueryParam(FETCH_LIMIT) String fetchLimit) throws ODKDatastoreException,
+  public Response getRowsSince(@QueryParam(QUERY_DATA_ETAG) String dataETag, @QueryParam(CURSOR_PARAMETER) String cursor, @QueryParam(FETCH_LIMIT) String fetchLimit, @QueryParam(GET_FULL_LOG) String getFullLog) throws ODKDatastoreException,
       PermissionDeniedException, InconsistentStateException, ODKTaskLockException, BadColumnNameException {
     int limit = (fetchLimit == null || fetchLimit.length() == 0) ? 2000 : Integer.valueOf(fetchLimit);
-    WebsafeRows websafeResult = dm.getRowsSince(dataETag, QueryResumePoint.fromWebsafeCursor(WebUtils.safeDecode(cursor)), limit);
+    boolean fullLog = (getFullLog == null) ? false : getFullLog.equalsIgnoreCase("true");
+    WebsafeRows websafeResult = dm.getRowsSince(dataETag, QueryResumePoint.fromWebsafeCursor(WebUtils.safeDecode(cursor)), limit, fullLog);
     RowResourceList rowResourceList = new RowResourceList(getResources(websafeResult.rows),
         websafeResult.dataETag, getTableUri(),
         WebUtils.safeEncode(websafeResult.websafeRefetchCursor),


### PR DESCRIPTION
By default, the /diff API only returns the latest version of a row in one fetch block. When the full history is needed, now one can pass getFullLog=true to get ALL changes

see https://forum.opendatakit.org/t/retrieving-the-full-history-of-an-odk-x-table-from-the-server/21314 for more context