### PR TITLE
Revert dependabot Spring Security update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <org.springframework.version>4.3.24.RELEASE</org.springframework.version>
         <org.slf4j.version>1.7.26</org.slf4j.version>
         <!-- log4j is not used -->
-        <org.springframework.security.version>5.3.3.RELEASE</org.springframework.security.version>
+        <org.springframework.security.version>4.2.13.RELEASE</org.springframework.security.version>
         <org.springframework.ldap.version>2.3.2.RELEASE</org.springframework.ldap.version>
         <!--
             keystore.propertyfile - define this in your settings.xml - the


### PR DESCRIPTION
This commit reverts ce92ef0b6a2e5599319dd3fd62e67d2602ad9a78

The new version of Spring Security breaks Sync Endpoint.