### PR TITLE
Circleci taketwo

### DIFF
--- a/sync-endpoint-docker-swarm/Dockerfile
+++ b/sync-endpoint-docker-swarm/Dockerfile
@@ -5,10 +5,11 @@ COPY resources/server.xml conf/
 COPY resources/logging.properties conf/
 
 COPY target/dependency/sync-endpoint-war.war /
-RUN apt-get update && apt-get install unzip
 RUN chmod +x /tmp/init.sh && \
     rm -rf /usr/local/tomcat/webapps/ROOT && \
-    unzip /sync-endpoint-war.war -d /usr/local/tomcat/webapps/ROOT && \
+    mkdir /usr/local/tomcat/webapps/ROOT && \
+    cd /usr/local/tomcat/webapps/ROOT && \
+    jar -xvf /sync-endpoint-war.war && \
     rm /sync-endpoint-war.war
 
 EXPOSE 8443

--- a/sync-endpoint-docker-test/Dockerfile
+++ b/sync-endpoint-docker-test/Dockerfile
@@ -6,10 +6,11 @@ COPY resources/logging.properties conf/
 
 COPY target/dependency/mysql-connector.jar lib/
 COPY target/dependency/sync-endpoint-war.war /
-RUN apt-get update && apt-get install unzip
 RUN chmod +x /tmp/init.sh && \
     rm -rf /usr/local/tomcat/webapps/ROOT && \
-    unzip /sync-endpoint-war.war -d /usr/local/tomcat/webapps/ROOT && \
+    mkdir /usr/local/tomcat/webapps/ROOT && \
+    cd /usr/local/tomcat/webapps/ROOT && \
+    jar -xvf /sync-endpoint-war.war && \
     rm /sync-endpoint-war.war
 
 EXPOSE 8888


### PR DESCRIPTION
Updated Dockerfiles to use jar instead of unzip to unpack war file (reduces build time significantly as it avoids expensive call to "apt update")