### PR TITLE
Bugfixes for sync-endpoint

### DIFF
--- a/src/main/java/org/opendatakit/aggregate/odktables/entity/serialization/SimpleJSONMessageReaderWriter.java
+++ b/src/main/java/org/opendatakit/aggregate/odktables/entity/serialization/SimpleJSONMessageReaderWriter.java
@@ -16,30 +16,36 @@
 
 package org.opendatakit.aggregate.odktables.entity.serialization;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
-import java.nio.charset.Charset;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opendatakit.aggregate.odktables.rest.ApiConstants;
 
 import javax.servlet.ServletContext;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
-
-import org.opendatakit.aggregate.odktables.rest.ApiConstants;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.StringWriter;
+import java.io.PrintWriter;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.Charset;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.GZIPInputStream;
 
 @Consumes({MediaType.APPLICATION_JSON})
 @Produces({MediaType.APPLICATION_JSON})
@@ -56,7 +62,10 @@ public class SimpleJSONMessageReaderWriter<T> implements MessageBodyReader<T>,
       this.buffer = buffer;
     }
   };
-  
+
+  @Context
+  private HttpHeaders headers;
+
   @Context
   ServletContext context;
 
@@ -74,22 +83,58 @@ public class SimpleJSONMessageReaderWriter<T> implements MessageBodyReader<T>,
         && mediaType.getSubtype().equals(MediaType.APPLICATION_JSON_TYPE.getSubtype());
   }
 
-  @Override
-  public T readFrom(Class<T> aClass, Type genericType, Annotation[] annotations,
-      MediaType mediaType, MultivaluedMap<String, String> map, InputStream stream)
-      throws IOException, WebApplicationException {
-    String encoding = getCharsetAsString(mediaType);
-    try {
-      if (!encoding.equalsIgnoreCase(DEFAULT_ENCODING)) {
-        throw new IllegalArgumentException("charset for the request is not utf-8");
-      }
-      InputStreamReader r = new InputStreamReader(stream,
-          Charset.forName(ApiConstants.UTF8_ENCODE));
-      return mapper.readValue(r, aClass);
-    } catch (Exception e) {
-      throw new IOException(e);
+   @Override
+    public T readFrom(Class<T> aClass, Type genericType, Annotation[] annotations,
+        MediaType mediaType, MultivaluedMap<String, String> map, InputStream stream)
+        throws IOException, WebApplicationException {
+        String encoding = getCharsetAsString(mediaType);
+        String requestBody = "";
+
+        try {
+            if (!encoding.equalsIgnoreCase(DEFAULT_ENCODING)) {
+                throw new IllegalArgumentException("Charset for the request is not utf-8, received: " + encoding);
+            }
+
+            // Check if request body is compressed (gzip)
+            String contentEncoding = (headers != null && headers.getRequestHeaders().containsKey("Content-Encoding"))
+                    ? headers.getRequestHeaders().get("Content-Encoding").get(0) : null;
+            if ("gzip".equalsIgnoreCase(contentEncoding)) {
+                // System.out.println("Detected Gzipped request, decompressing...");
+                stream = new GZIPInputStream(stream);
+            }
+
+            // Read the InputStream into a String before parsing
+            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(stream, Charset.forName(ApiConstants.UTF8_ENCODE)));
+            StringBuilder rawInput = new StringBuilder();
+            String line;
+            while ((line = bufferedReader.readLine()) != null) {
+                rawInput.append(line).append("\n");
+            }
+            requestBody = rawInput.toString();
+
+            // System.out.println("Decompressed Request Body: " + requestBody);
+            return mapper.readValue(requestBody, aClass);
+        } catch (Exception e) {
+            System.err.println("Unexpected error while reading JSON: " + e.getMessage()); 
+            System.out.println("Received Encoding: " + encoding);            
+            if (headers != null) {
+                for (java.util.Map.Entry<String, List<String>> header : headers.getRequestHeaders().entrySet()) {
+                    System.out.println("Header: " + header.getKey() + " = " + String.join(", ", header.getValue()));
+                }
+            }
+            
+
+            // Log raw request body in case of an error
+            System.err.println("Raw Request Body (on error): " + requestBody);
+
+            // Log stack trace for debugging
+            StringWriter sw = new StringWriter();
+            e.printStackTrace(new PrintWriter(sw));
+            System.err.println(sw.toString());
+
+            throw new IOException("Error parsing JSON request: " + e.getMessage(), e);
+        }
     }
-  }
 
   @Override
   public void writeTo(T o, Class<?> aClass, Type type, Annotation[] annotations,
@@ -103,7 +148,7 @@ public class SimpleJSONMessageReaderWriter<T> implements MessageBodyReader<T>,
 
       /**
        * This is an optimization because of the weird way Wink handles request/response
-       * processing. I'd like to do post-processing on the constructed response, but 
+       * processing. I'd like to do post-processing on the constructed response, but
        * am forced to do pre-processing. We only do this for JSON response path.
        */
       byte[] bytes = null;

--- a/sync-endpoint-docker-swarm/resources/server.xml
+++ b/sync-endpoint-docker-swarm/resources/server.xml
@@ -65,6 +65,7 @@
          Define a non-SSL/TLS HTTP/1.1 Connector on port 80
     -->
     <Connector port="8080" protocol="HTTP/1.1"
+	       secretRequired="false" 
                connectionTimeout="20000"
                redirectPort="8443" 
                maxPostSize="33554432" />

--- a/sync-endpoint-docker-swarm/resources/server.xml
+++ b/sync-endpoint-docker-swarm/resources/server.xml
@@ -88,7 +88,8 @@
 <Connector protocol="org.apache.coyote.http11.Http11NioProtocol" port="8443"
 	maxThreads="150" scheme="https" secure="true" maxPostSize="33554432"
 	SSLEnabled="true" keystoreFile="/run/secrets/odksync-tomcat.keystore" 
-	keystorePass="changeit" clientAuth="false" sslProtocol="TLS"/>
+	keystorePass="changeit" clientAuth="false" sslProtocol="TLS" secretRequired="false" 
+	/>
  
     <!-- Define a SSL/TLS HTTP/1.1 Connector on port 8443 with HTTP/2
          This connector uses the APR/native implementation which always uses
@@ -110,7 +111,7 @@
     -->
 
     <!-- Define an AJP 1.3 Connector on port 8009 -->
-    <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" />
+    <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" secretRequired="false"/>
 
 
     <!-- An Engine represents the entry point (within Catalina) that processes


### PR DESCRIPTION
This PR fixes a couple of configuration errors introduced by catalina's "secretRequired" now defaulting to true ("fixed" by setting it to false).
Also fixes an error related to gzipped requests during sync...